### PR TITLE
Docker push

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -44,7 +44,7 @@ jobs:
         mvn -Dtest="EndToEndTests" test
 
   build:
-    # if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref == 'refs/heads/master' }}
     needs: test
     runs-on: ubuntu-latest
     steps:
@@ -94,7 +94,7 @@ jobs:
           path: nodenpm.tar.gz
 
   deploy:
-    # if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref == 'refs/heads/master' }}
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -80,6 +80,7 @@ jobs:
         cd springdb
         mvn -Dtest="EndToEndTests" test
   deploy:
+    if: ${{ github.ref == 'refs/heads/master' }}
     needs: test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,55 +14,18 @@ on:
     - 'master'
 
 jobs:  
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-        cache: maven
-    - name: Set up nodejs environment
-      uses: actions/setup-node@v2
-      with:
-        node-version: '16'
-        cache: 'npm'
-        cache-dependency-path: 'springdb/frontend/**/package-lock.json'
-    - name: Build with Maven
-      run: |
-        cd springdb
-        mvn -DskipTests install
-#        ./mvnw -B package --file pom.xml
-
-    - name: Upload back end artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: backend
-        path: springdb/target/*.jar
-
-    - name: Create front end archive
-      run: tar -zcf frontend.tar.gz springdb/frontend
-
-    - name: Upload front end artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: frontend
-        path: frontend.tar.gz
-
   test:
-    needs: build
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
         java-version: '11'
         distribution: 'temurin'
         cache: maven
+
     - name: "Set up nodejs environment"
       uses: actions/setup-node@v2
       with:
@@ -79,9 +42,51 @@ jobs:
       run: |
         cd springdb
         mvn -Dtest="EndToEndTests" test
-  deploy:
+
+  build:
     if: ${{ github.ref == 'refs/heads/master' }}
     needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Set up nodejs environment
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: 'npm'
+          cache-dependency-path: 'springdb/frontend/**/package-lock.json'
+
+      - name: Build with Maven
+        run: |
+          cd springdb
+          mvn -DskipTests install
+
+      - name: Upload back end artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: backend
+          path: springdb/target/*.jar
+
+      - name: Create front end archive
+        run: tar -zcf frontend.tar.gz springdb/frontend
+
+      - name: Upload front end artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: frontend
+          path: frontend.tar.gz
+
+  deploy:
+    if: ${{ github.ref == 'refs/heads/master' }}
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -44,7 +44,7 @@ jobs:
         mvn -Dtest="EndToEndTests" test
 
   build:
-    if: ${{ github.ref == 'refs/heads/master' }}
+    # if: ${{ github.ref == 'refs/heads/master' }}
     needs: test
     runs-on: ubuntu-latest
     steps:
@@ -84,8 +84,17 @@ jobs:
           name: frontend
           path: frontend.tar.gz
 
+      - name: Create node and npm archive
+        run: tar -zcf nodenpm.tar.gz springdb/target/node
+
+      - name: Upload node and npm artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: nodenpm
+          path: nodenpm.tar.gz
+
   deploy:
-    if: ${{ github.ref == 'refs/heads/master' }}
+    # if: ${{ github.ref == 'refs/heads/master' }}
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -106,6 +115,14 @@ jobs:
 
       - name: Move front end files to expected location
         run: tar -xzf frontend.tar.gz
+
+      - name: Download node and npm artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: nodenpm
+
+      - name: Move front end files to expected location
+        run: tar -xzf nodenpm.tar.gz
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM adoptopenjdk/openjdk11:latest
 ARG JAR_FILE=springdb/target/*.jar
 ARG FRONT_END=springdb/frontend
+ARG NODE_NPM=springdb/target/node
 ARG ENTRY=start.sh
 COPY ${JAR_FILE} app.jar
 COPY ${FRONT_END} frontend
+COPY ${NODE_NPM} node
 COPY ${ENTRY} start.sh
-RUN apt-get update && apt-get install -y npm
-RUN cd frontend && npm install n && node_modules/n/bin/n stable
 ENTRYPOINT ["/start.sh"]

--- a/start.sh
+++ b/start.sh
@@ -4,6 +4,7 @@
 java -jar /app.jar &
 
 # Start the front end
+export PATH="/node:$PATH"
 cd frontend
 npm run start &
 


### PR DESCRIPTION
Trims up the docker image a bit, and improve the build times.
Run tests first, and only then build the production image if the tests pass.
Only do a production build and push to docker hub from the master branch.