### PR TITLE
Docker push

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,23 @@ Otherwise, these jobs are skipped.
 Separating the build and deploy jobs has two main advantages.
 First, it's clear at a glance if a failure occurred during Maven or during Docker Hub operations.
 Second, the build artifacts are available for later inspection if desired for troubleshooting.
+
+## Running against Neo4j Desktop
+
+* Start Neo4j Desktop
+* Create a new project if you haven't set one up before
+  * Add a local DBMS to the project
+  * Set the password to match that in src/main/resources/application.properties
+  * In the DBMS settings (click the ... while hovering over it):
+    * Search for "non-local connections"
+    * Uncomment the next line that reads `dbms.default_listen_address=0.0.0.0`
+    * Apply the change and close
+    * Start the DBMS
+* Get the latest docker image using `docker pull gradvek/app`
+* Run the container using `docker run -p 3000:3000 -p 8080:8080 gradvek/app`
+* Open your browser to localhost:3000
+* Inspect the state of the DB with Browser or Bloom
+* When you're done:
+  * Find the running container id with `docker ps --filter status=running -q`
+  * Stop the container with `docker stop <container_id>`
+  * Or if you're using bash, simply run `docker stop $(docker ps --filter status=running -q)`

--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
 # gradvek
 GRaph of ADVerse Event Knowledge
 
-SETUP
-=======
+## Build process
 
-TODO : OpenTargets Download instructions 
-----------------------------------------
+GitHub Actions builds the artifacts needed for deployment.
+There is one workflow divided into three jobs:
+* test
+  * The first job uses the Maven `test` goal to run regression tests.
+* build
+  * The second job uses the Maven `install` goal to create a production build.  The build artifacts are saved for use in the next job.
+* deploy
+  * The build artifacts from the previous job are restored.  Then the main project Dockerfile is used to generate an image, which is pushed to Docker Hub.
+
+Prior to building and deploying in production, the [GitHub context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) is checked to ensure that the `master` branch is being used.
+Otherwise, these jobs are skipped.
+
+Separating the build and deploy jobs has two main advantages.
+First, it's clear at a glance if a failure occurred during Maven or during Docker Hub operations.
+Second, the build artifacts are available for later inspection if desired for troubleshooting.

--- a/springdb/src/main/java/com/semis/gradvek/springdb/Neo4jDriver.java
+++ b/springdb/src/main/java/com/semis/gradvek/springdb/Neo4jDriver.java
@@ -22,6 +22,10 @@ public class Neo4jDriver {
 
     private static final Map<String, Neo4jDriver> mInstances = new HashMap<> ();
     public static Neo4jDriver instance (String uri, String user, String password) {
+		String uriOverride = System.getenv("NEO4JURL");
+		if (uriOverride != null) {
+			uri = uriOverride;
+		}
     	Neo4jDriver ret = mInstances.getOrDefault(uri, null);
     	if (ret == null) {
     		ret = new Neo4jDriver(uri, user, password);

--- a/springdb/src/main/resources/application.properties
+++ b/springdb/src/main/resources/application.properties
@@ -1,4 +1,3 @@
-# neo4j.url=bolt://host.docker.internal:7687
 neo4j.url=bolt://localhost:7687
 neo4j.user=neo4j
 neo4j.password=gradvek

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 # Start the back end
+# https://unix.stackexchange.com/a/561524
+export NEO4JURL=bolt://$(for i in $(echo "$(cat /proc/net/route | head -2 | tail -1 | awk '{print $3}')" | sed -E 's/(..)(..)(..)(..)/\4 \3 \2 \1/' ) ; do printf "%d." $((16#$i)); done | sed 's/.$//'):7687
 java -jar /app.jar &
 
 # Start the front end


### PR DESCRIPTION
Add documentation
Allow the Docker container to override the Neo4j URL with an environment variable
I believe the change to start.sh is cross-platform, since host.docker.internal doesn't work on Linux.  Hopefully somebody on Windows or Mac can try it out and make sure?