### PR TITLE
UI Enhancements & Fix MORE spaceing and quotes issues by VSCode in the prior commit

### DIFF
--- a/springdb/frontend/src/layouts/dashboard/DashboardTopbar.js
+++ b/springdb/frontend/src/layouts/dashboard/DashboardTopbar.js
@@ -17,7 +17,7 @@ export default function DashboardTopbar() {
 
             <Box>
                 <Button color='inherit' href='/dashboard/app'>
-                    <Iconify icon='ant-design:home-filled' width={22} height={22} sx={{mr: 1}}/>
+                    <Iconify icon='ant-design:search' width={22} height={22} sx={{mr: 1}}/>
                     <Typography variant="subtitle1" component="div" sx={{mr: 10}}>
                         Query
                     </Typography>

--- a/springdb/frontend/src/theme/overrides/Accordion.js
+++ b/springdb/frontend/src/theme/overrides/Accordion.js
@@ -7,10 +7,10 @@ export default function Accordion() {
   
         styleOverrides: {
           root: {
-            backgroundImage: "none",
-            border: "0px solid transparent",
-            "&:before": {
-              backgroundColor: "transparent"
+            backgroundImage: 'none',
+            border: '0px solid transparent',
+            '&:before': {
+              backgroundColor: 'transparent'
             }
           }
         }

--- a/springdb/frontend/src/theme/overrides/Button.js
+++ b/springdb/frontend/src/theme/overrides/Button.js
@@ -6,7 +6,7 @@ export default function Button(theme) {
       styleOverrides: {
         root: {
           fontSize: theme.typography.pxToRem(16),
-          "&:hover": {
+          '&:hover': {
             boxShadow: 'none'
           }
         },


### PR DESCRIPTION
Here are my enhancements based on @iEatYanYans laundry list. Fix issues from VSCode commit in the prior PR

Standardize & increase website font size
Round weigh decimal places to 2
increase checkbox sizes in data management screen
Accordion UI (remove/round top border + make it prettier)
6c. Remove the hardcoded “Result for… XYZ…”
7a. change query icon
7b. Font size (see point above about standardizing font size)